### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_user_displayname/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_user_displayname/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_user_displayname/actions/workflows/test-and-release.yml)
 
-# ep\_user\_displayname
+# User Display Names for Etherpad
 
 Etherpad plugin that initializes the name displayed in the user list from a
 value in the user's account settings. The account settings can come from


### PR DESCRIPTION
Replace the placeholder `ep_user_displayname` heading in README.md with "User Display Names for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.